### PR TITLE
Add test cases

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/04-throttle/_js.view/test.js
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/04-throttle/_js.view/test.js
@@ -40,6 +40,12 @@ describe("throttle(f, 1000)", function() {
     assert.equal(log, "136"); // the last call was f(6)
   });
 
+  it("execute after 1000ms", function() {
+    this.clock.tick(1000);
+    f1000(7);
+    assert.equal(log, "1367");
+  });
+
   after(function() {
     this.clock.restore();
   });


### PR DESCRIPTION
I found  a throttling method in the comments section that passed all the current tests but was wrong.So I added a test case to find this type of error.With this wrapping method, if the interval between two calls is greater than 1000ms, the wrapped method becomes invalid.

``` javascript
function throttle(func, period) {
  let savedArgs
  let savedThis
  let start = true

  function runFunc() {
    if (savedArgs) {
      func.apply(savedThis, savedArgs)
      savedArgs = undefined
      setTimeout(runFunc, period)
    }
  }

  function wrapper(...rest) {
    savedThis = this
    savedArgs = rest
    if (start) {
      start = false
      runFunc()
    }
  }
  return wrapper
}
```